### PR TITLE
Replace automatic tab opening with explicit directive

### DIFF
--- a/components/interface/client/package-lock.json
+++ b/components/interface/client/package-lock.json
@@ -21,6 +21,7 @@
         "rehype-github-alerts": "^4.1.1",
         "rehype-mermaid": "^3.0.0",
         "rehype-raw": "^7.0.0",
+        "remark-directive": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "sass": "^1.89.2"
       },
@@ -4573,6 +4574,27 @@
         "node": ">= 20"
       }
     },
+    "node_modules/mdast-util-directive": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-directive/-/mdast-util-directive-3.1.0.tgz",
+      "integrity": "sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
@@ -4971,6 +4993,25 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+      "integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "parse-entities": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -6269,6 +6310,22 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-directive": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-directive/-/remark-directive-4.0.0.tgz",
+      "integrity": "sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-directive": "^3.0.0",
+        "micromark-extension-directive": "^4.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/components/interface/client/package.json
+++ b/components/interface/client/package.json
@@ -25,6 +25,7 @@
     "rehype-github-alerts": "^4.1.1",
     "rehype-mermaid": "^3.0.0",
     "rehype-raw": "^7.0.0",
+    "remark-directive": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "sass": "^1.89.2"
   },

--- a/components/interface/client/src/TabContext.jsx
+++ b/components/interface/client/src/TabContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, use, useCallback, useContext, useState } from "react";
+import { createContext, useCallback, useContext, useState } from "react";
 
 const TabContext = createContext([]);
 
@@ -7,8 +7,9 @@ export function TabContextProvider({ children }) {
   const [activeTab, setActiveTab] = useState(null);
 
   const addTab = useCallback(
-    (url) => {
-      setTabs((prevTabs) => [...prevTabs, url]);
+    (url, title) => {
+      if (!title) title = url;
+      setTabs((prevTabs) => [...prevTabs, { url, title }]);
       setActiveTab(url);
     },
     [setTabs, setActiveTab],
@@ -16,7 +17,7 @@ export function TabContextProvider({ children }) {
 
   const removeTab = useCallback(
     (url) => {
-      setTabs((prevTabs) => prevTabs.filter((tab) => tab !== url));
+      setTabs((prevTabs) => prevTabs.filter((tab) => tab.url !== url));
       setActiveTab((prevActiveTab) =>
         prevActiveTab === url ? null : prevActiveTab,
       );
@@ -25,10 +26,12 @@ export function TabContextProvider({ children }) {
   );
 
   const displayLink = useCallback(
-    (url) => {
+    (url, title) => {
+      if (!title) title = url;
+
       setTabs((prevTabs) => {
-        if (!prevTabs.includes(url)) {
-          return [...prevTabs, url];
+        if (!prevTabs.find((tab) => tab.url === url)) {
+          return [...prevTabs, { url, title }];
         }
         return prevTabs;
       });

--- a/components/interface/client/src/components/ExternalContentPanel/ExternalContentPanel.jsx
+++ b/components/interface/client/src/components/ExternalContentPanel/ExternalContentPanel.jsx
@@ -1,53 +1,33 @@
 import { IdePlaceholder } from "./IdePlaceholder";
 import { useTabs } from "../../TabContext";
-import Nav from "react-bootstrap/Nav";
-import Button from "react-bootstrap/Button";
 import "./ExternalContentPanel.scss";
-
-function getTabTitle(url) {
-  if (url === "http://localhost:8085") return "VS Code";
-  return url;
-}
+import { ExternalTabs } from "./ExternalTabs";
+import { useRef } from "react";
 
 export function ExternalContentPanel() {
   const { tabs, setActiveTab, activeTab, addTab, removeTab } = useTabs();
+  const iframeRef = useRef();
 
   return (
     <div className="d-flex flex-fill flex-column">
       <div className="p-3 pt-2 pb-0 bg-secondary-subtle">
-        <Nav
-          variant="tabs"
-          activeKey={activeTab}
-          onSelect={(selectedKey) => setActiveTab(selectedKey)}
-          id="external-content-tabs"
-        >
-          {tabs.map((tab) => (
-            <Nav.Item key={tab} className="me-2 ms-2">
-              <Nav.Link eventKey={tab} className="p-1 ps-3 pe-1">
-                <span className="me-3">{getTabTitle(tab)}</span>
-
-                {!tab.endsWith("localhost:8085") && (
-                  <Button
-                    size="sm"
-                    variant="default"
-                    className="rounded-circle p-1 pt-0 pb-0"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      removeTab(tab);
-                    }}
-                  >
-                    &times;
-                  </Button>
-                )}
-              </Nav.Link>
-            </Nav.Item>
-          ))}
-        </Nav>
+        <ExternalTabs
+          activeTab={activeTab}
+          setActiveTab={setActiveTab}
+          tabs={tabs}
+          onTabRemoval={removeTab}
+        />
       </div>
       {activeTab ? (
-        <iframe style={{ flex: 1, border: "none" }} src={activeTab} />
+        <iframe
+          ref={iframeRef}
+          style={{ flex: 1, border: "none" }}
+          src={activeTab}
+        />
       ) : (
-        <IdePlaceholder onLaunch={() => addTab("http://localhost:8085")} />
+        <IdePlaceholder
+          onLaunch={() => addTab("http://localhost:8085", "Workspace")}
+        />
       )}
     </div>
   );

--- a/components/interface/client/src/components/ExternalContentPanel/ExternalContentPanel.scss
+++ b/components/interface/client/src/components/ExternalContentPanel/ExternalContentPanel.scss
@@ -9,5 +9,10 @@
       background-color: var(--bs-secondary);
       color: var(--bs-white);
     }
+
+    span {
+      position: relative;
+      top: 1px;
+    }
   }
 }

--- a/components/interface/client/src/components/ExternalContentPanel/ExternalTabs.jsx
+++ b/components/interface/client/src/components/ExternalContentPanel/ExternalTabs.jsx
@@ -1,0 +1,49 @@
+import Nav from "react-bootstrap/Nav";
+import Button from "react-bootstrap/Button";
+
+export function ExternalTabs({
+  activeTab,
+  setActiveTab,
+  tabs,
+  onTabRemoval,
+  onRefreshClick,
+}) {
+  return (
+    <Nav
+      variant="tabs"
+      activeKey={activeTab}
+      onSelect={(selectedKey) => setActiveTab(selectedKey)}
+      id="external-content-tabs"
+    >
+      {tabs.map((tab) => (
+        <Nav.Item key={tab.url} className="me-2 ms-2">
+          <Nav.Link
+            eventKey={tab.url}
+            href={tab.url}
+            className="p-1 ps-3 pe-1"
+            onClick={(e) => {
+              e.preventDefault();
+            }}
+          >
+            <span className="me-3">{tab.title}</span>
+
+            {!tab.title !== "Workspace" && (
+              <Button
+                size="sm"
+                variant="default"
+                className="rounded-circle p-1 pt-0 pb-0"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  onTabRemoval(tab.url);
+                }}
+              >
+                <span className="material-symbols-outlined">close</span>
+              </Button>
+            )}
+          </Nav.Link>
+        </Nav.Item>
+      ))}
+    </Nav>
+  );
+}

--- a/components/interface/client/src/components/WorkshopPanel/WorkshopBody.jsx
+++ b/components/interface/client/src/components/WorkshopPanel/WorkshopBody.jsx
@@ -1,17 +1,7 @@
 import { useActiveSection, useWorkshop } from "../../WorkshopContext";
-import { MarkdownHooks } from "react-markdown";
-import remarkGfm from "remark-gfm";
-import rehypeRaw from "rehype-raw";
-import rehypeMermaid from "rehype-mermaid";
-import { rehypeGithubAlerts } from "rehype-github-alerts";
-import { CodeBlock } from "./markdown/CodeBlock";
-import { remarkCodeIndexer } from "./markdown/codeIndexer";
 import { useEffect, useRef } from "react";
-import { ExternalLink } from "./markdown/ExternalLink";
 import Button from "react-bootstrap/Button";
-import Image from "react-bootstrap/Image";
-import { RenderedImage } from "./markdown/RenderedImage";
-import { RenderedSvg } from "./markdown/RenderedSvg";
+import { MarkdownRenderer } from "./markdown/MarkdownRenderer";
 
 export function WorkshopBody() {
   const bodyRef = useRef();
@@ -38,18 +28,7 @@ export function WorkshopBody() {
     <>
       <div className="overflow-auto" ref={bodyRef}>
         <div className="workshop-body p-5 pt-3 pb-3">
-          <MarkdownHooks
-            remarkPlugins={[remarkGfm, remarkCodeIndexer]}
-            rehypePlugins={[rehypeRaw, rehypeMermaid, rehypeGithubAlerts]}
-            components={{
-              code: CodeBlock,
-              a: ExternalLink,
-              img: RenderedImage,
-              svg: RenderedSvg,
-            }}
-          >
-            {activeSection.content}
-          </MarkdownHooks>
+          <MarkdownRenderer>{activeSection.content}</MarkdownRenderer>
         </div>
         <div className="workshop-footer d-flex justify-content-between p-3 border-top">
           <div>

--- a/components/interface/client/src/components/WorkshopPanel/markdown/ExternalLink.jsx
+++ b/components/interface/client/src/components/WorkshopPanel/markdown/ExternalLink.jsx
@@ -1,15 +1,6 @@
-import { useTabs } from "../../../TabContext";
-
 export function ExternalLink({ href, children, ...rest }) {
-  const { displayLink } = useTabs();
-
-  const handleClick = (e) => {
-    e.preventDefault();
-    displayLink(href);
-  };
-
   return (
-    <a href={href} onClick={handleClick} {...rest}>
+    <a href={href} target="_blank" rel="noopener noreferrer" {...rest}>
       {children}
     </a>
   );

--- a/components/interface/client/src/components/WorkshopPanel/markdown/MarkdownRenderer.jsx
+++ b/components/interface/client/src/components/WorkshopPanel/markdown/MarkdownRenderer.jsx
@@ -1,0 +1,27 @@
+import { MarkdownHooks } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import rehypeRaw from "rehype-raw";
+import rehypeMermaid from "rehype-mermaid";
+import { rehypeGithubAlerts } from "rehype-github-alerts";
+import { CodeBlock } from "./CodeBlock";
+import { remarkCodeIndexer } from "./codeIndexer";
+import { ExternalLink } from "./ExternalLink";
+import { RenderedImage } from "./RenderedImage";
+import { RenderedSvg } from "./RenderedSvg";
+
+export function MarkdownRenderer({ children }) {
+  return (
+    <MarkdownHooks
+      remarkPlugins={[remarkGfm, remarkCodeIndexer]}
+      rehypePlugins={[rehypeRaw, rehypeMermaid, rehypeGithubAlerts]}
+      components={{
+        code: CodeBlock,
+        a: ExternalLink,
+        img: RenderedImage,
+        svg: RenderedSvg,
+      }}
+    >
+      {children}
+    </MarkdownHooks>
+  );
+}

--- a/components/interface/client/src/components/WorkshopPanel/markdown/MarkdownRenderer.jsx
+++ b/components/interface/client/src/components/WorkshopPanel/markdown/MarkdownRenderer.jsx
@@ -2,23 +2,32 @@ import { MarkdownHooks } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 import rehypeMermaid from "rehype-mermaid";
+import remarkDirective from "remark-directive";
 import { rehypeGithubAlerts } from "rehype-github-alerts";
 import { CodeBlock } from "./CodeBlock";
 import { remarkCodeIndexer } from "./codeIndexer";
 import { ExternalLink } from "./ExternalLink";
 import { RenderedImage } from "./RenderedImage";
 import { RenderedSvg } from "./RenderedSvg";
+import { tabDirective } from "./reactDirective";
+import { TabLink } from "./TabLink";
 
 export function MarkdownRenderer({ children }) {
   return (
     <MarkdownHooks
-      remarkPlugins={[remarkGfm, remarkCodeIndexer]}
+      remarkPlugins={[
+        remarkGfm,
+        remarkCodeIndexer,
+        remarkDirective,
+        tabDirective,
+      ]}
       rehypePlugins={[rehypeRaw, rehypeMermaid, rehypeGithubAlerts]}
       components={{
         code: CodeBlock,
         a: ExternalLink,
         img: RenderedImage,
         svg: RenderedSvg,
+        tablink: TabLink,
       }}
     >
       {children}

--- a/components/interface/client/src/components/WorkshopPanel/markdown/TabLink.jsx
+++ b/components/interface/client/src/components/WorkshopPanel/markdown/TabLink.jsx
@@ -1,0 +1,18 @@
+import { useTabs } from "../../../TabContext";
+
+export function TabLink({ href, title, children }) {
+  const { displayLink } = useTabs();
+
+  return (
+    <a
+      href={href}
+      title={title}
+      onClick={(e) => {
+        e.preventDefault();
+        displayLink(href, title);
+      }}
+    >
+      {children}
+    </a>
+  );
+}

--- a/components/interface/client/src/components/WorkshopPanel/markdown/reactDirective.js
+++ b/components/interface/client/src/components/WorkshopPanel/markdown/reactDirective.js
@@ -1,0 +1,38 @@
+// import {h} from 'hastscript'
+import { visit } from "unist-util-visit";
+
+/**
+ * Works with the remark-directive plugin to transform custom directives into
+ * components that can be used by react-markdown.
+ *
+ * To support a custom directive, simply define the React component and add it
+ * to the components prop of MarkdownRenderer. The name of the component must
+ * match the name of the directive.
+ *
+ * @returns
+ */
+export function tabDirective() {
+  /**
+   * @param {Root} tree
+   *   Tree.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  return (tree) => {
+    visit(
+      tree,
+      ["textDirective", "leafDirective", "containerDirective"],
+      (node) => {
+        const data = node.data || (node.data = {});
+
+        // This is what's supposed to work. But "h" was not a function?
+        // const { properties } = h(node.name, node.attributes);
+
+        data.hName = node.name;
+        data.hProperties = {
+          ...node.attributes,
+        };
+      },
+    );
+  };
+}

--- a/docs/markdown-options.md
+++ b/docs/markdown-options.md
@@ -75,3 +75,15 @@ If a user clicks this "Save file" button, a `compose.yaml` file will be created 
 
 - If the file already exists, the contents will be replaced with what is provided in the code block.
 - All required directories leading up to the file will automatically be created
+
+
+
+## Links
+
+By default, all links are configured to open new browser tabs when clicked.
+
+If you want to add another tab to the right-hand panel, you can use the following directive:
+
+    ::tabLink[Link text]{href="http://localhost:3000" title="Tab title"}
+
+This will render a link with the visible text of "Link text" pointing to "http://localhost:3000". When clicked, a new tab will be created with the title of "Tab title".


### PR DESCRIPTION
Recognizing many pages have iframe blocking directives in place, it is realized it was a mistake to automatically open all links in tabs. This change introduces a custom Markdown directive that will render a link that opens a new tab:

```
::tabLink[Link text]{href="http://localhost:3000" title="Tab title"}
```

Rendered link:
<img width="107" height="37" alt="image" src="https://github.com/user-attachments/assets/a5c9c851-3585-4c6c-b280-a1dc5e1ea5c6" />

Tab created on click:
<img width="140" height="54" alt="image" src="https://github.com/user-attachments/assets/a9ab3cdc-4cfe-4d41-82a3-6132bc14a15e" />


Resolves #88