### PR TITLE
Add refresh button to active tab

### DIFF
--- a/components/interface/client/src/components/ExternalContentPanel/ExternalContentPanel.jsx
+++ b/components/interface/client/src/components/ExternalContentPanel/ExternalContentPanel.jsx
@@ -16,6 +16,11 @@ export function ExternalContentPanel() {
           setActiveTab={setActiveTab}
           tabs={tabs}
           onTabRemoval={removeTab}
+          onRefreshClick={() => {
+            const url = new URL(iframeRef.current.src);
+            url.searchParams.set("t", Date.now());
+            iframeRef.current.src = url.toString();
+          }}
         />
       </div>
       {activeTab ? (

--- a/components/interface/client/src/components/ExternalContentPanel/ExternalTabs.jsx
+++ b/components/interface/client/src/components/ExternalContentPanel/ExternalTabs.jsx
@@ -27,6 +27,21 @@ export function ExternalTabs({
           >
             <span className="me-3">{tab.title}</span>
 
+            {activeTab === tab.url && (
+              <Button
+                size="sm"
+                variant="default"
+                className="rounded-circle p-1 pt-0 pb-0"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  onRefreshClick();
+                }}
+              >
+                <span className="material-symbols-outlined">refresh</span>
+              </Button>
+            )}
+
             {!tab.title !== "Workspace" && (
               <Button
                 size="sm"


### PR DESCRIPTION
Adds a refresh tab to only the active tab. Useful in situations where apps may take a little bit to load, code changes are hot reloaded, etc.