### PR TITLE
Fix bug allowing the workspace tab from being closed

### DIFF
--- a/components/interface/client/src/components/ExternalContentPanel/ExternalTabs.jsx
+++ b/components/interface/client/src/components/ExternalContentPanel/ExternalTabs.jsx
@@ -42,7 +42,7 @@ export function ExternalTabs({
               </Button>
             )}
 
-            {!tab.title !== "Workspace" && (
+            {tab.title !== "Workspace" && (
               <Button
                 size="sm"
                 variant="default"


### PR DESCRIPTION
A small logic issue allowed the workspace tab to be closed, which we don't want to allow.