### PR TITLE
Use the :dev tag for all images for main branch publishing

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -55,6 +55,8 @@ jobs:
           docker compose version
 
           if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            sed -i "s/:latest/:dev/g" compose.run.yaml
+            sed -i "s/:latest/:dev/g" compose.content-dev.yaml
             echo "y" | docker compose -f compose.run.yaml publish dockersamples/labspace:dev --with-env -y
             echo "y" | docker compose -f compose.content-dev.yaml publish dockersamples/labspace-content-dev:dev --with-env -y
           else


### PR DESCRIPTION
The main branch is supposed to publish the `:dev` variation of the Compose files, but those Compose files were still using the latest tags... which are only updated on tagged releases. This fixes that.