### PR TITLE
Update codercom/code-server to 4.104.2, pin JDK and Docker CLI versions, and add MCP Gateway CLI plugin

### DIFF
--- a/components/workspace/base/Dockerfile
+++ b/components/workspace/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM codercom/code-server:4.103.2
+FROM codercom/code-server:4.104.2
 
 ENV CS_DISABLE_GETTING_STARTED_OVERRIDE=1
 ENV PORT=8085
@@ -6,9 +6,10 @@ EXPOSE 8085
 
 RUN mkdir -p ~/.docker/cli-plugins && chown -R 1000:1000 ~/.docker
 COPY --link --from=docker /usr/local/bin/docker /usr/local/bin/docker
-COPY --link --chown=1000:1000 --from=docker /usr/local/libexec/docker/cli-plugins /home/coder/.docker/cli-plugins
-COPY --link --chown=1000:1000 --from=docker/scout-cli:1.18 /docker-scout /home/coder/.docker/cli-plugins/docker-scout
-COPY --link --chown=1000:1000 --from=docker/docker-model-cli-desktop-module:v0.1.40 /cli-plugins/model/linux/docker-model /home/coder/.docker/cli-plugins/docker-model
+COPY --link --chown=1000:1000 --from=docker:28.4.0 /usr/local/libexec/docker/cli-plugins /home/coder/.docker/cli-plugins
+COPY --link --chown=1000:1000 --from=docker/scout-cli:1.18.4 /docker-scout /home/coder/.docker/cli-plugins/docker-scout
+COPY --link --chown=1000:1000 --from=docker/docker-model-cli-desktop-module:v0.1.42 /cli-plugins/model/linux/docker-model /home/coder/.docker/cli-plugins/docker-model
+COPY --link --chown=1000:1000 --from=docker/docker-mcp-cli-desktop-module:v0.21.0 /cli-plugins/mcp/linux/docker-mcp /home/coder/.docker/cli-plugins/docker-mcp
 
 USER root
 

--- a/components/workspace/java/Dockerfile
+++ b/components/workspace/java/Dockerfile
@@ -18,7 +18,7 @@ RUN set -eux; \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
-COPY --from=eclipse-temurin:21-jdk /opt/java/openjdk /opt/java/openjdk
+COPY --from=eclipse-temurin:21.0.8_9-jdk /opt/java/openjdk /opt/java/openjdk
 RUN find "$JAVA_HOME/lib" -name '*.so' -exec dirname '{}' ';' | sort -u > /etc/ld.so.conf.d/docker-openjdk.conf; \
     ldconfig; \
     java -Xshare:dump;


### PR DESCRIPTION
Also includes a few version pins, including the following:

- Pin docker to `docker:28.4.0`
- Pin Scout CLI to `docker/scout-cli:1.18.4`
- Update `docker-model-cli` to `0.1.42`
- Add the MCP Gateway, pinning it to `0.21.0`